### PR TITLE
check to see if Stripe classes already exist before loading

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -14,43 +14,105 @@ if (!function_exists('mb_detect_encoding')) {
 }
 
 // Stripe singleton
-require(dirname(__FILE__) . '/Stripe/Stripe.php');
+if (!class_exists('Stripe')) {
+	require(dirname(__FILE__) . '/Stripe/Stripe.php');
+}
 
 // Utilities
-require(dirname(__FILE__) . '/Stripe/Util.php');
-require(dirname(__FILE__) . '/Stripe/Util/Set.php');
+if (!class_exists('Stripe_Util')) {
+	require(dirname(__FILE__) . '/Stripe/Util.php');
+	require(dirname(__FILE__) . '/Stripe/Util/Set.php');
+}
 
 // Errors
-require(dirname(__FILE__) . '/Stripe/Error.php');
-require(dirname(__FILE__) . '/Stripe/ApiError.php');
-require(dirname(__FILE__) . '/Stripe/ApiConnectionError.php');
-require(dirname(__FILE__) . '/Stripe/AuthenticationError.php');
-require(dirname(__FILE__) . '/Stripe/CardError.php');
-require(dirname(__FILE__) . '/Stripe/InvalidRequestError.php');
-require(dirname(__FILE__) . '/Stripe/RateLimitError.php');
+if (!class_exists('Stripe_Error')) {
+	require(dirname(__FILE__) . '/Stripe/Error.php');
+}
+if (!class_exists('Stripe_ApiError')) {
+	require(dirname(__FILE__) . '/Stripe/ApiError.php');
+}
+if (!class_exists('Stripe_ApiConnectionError')) {
+	require(dirname(__FILE__) . '/Stripe/ApiConnectionError.php');
+}
+if (!class_exists('Stripe_ApiConnectionError')) {
+	require(dirname(__FILE__) . '/Stripe/AuthenticationError.php');
+}
+if (!class_exists('Stripe_CardError')) {
+	require(dirname(__FILE__) . '/Stripe/CardError.php');
+}
+if (!class_exists('Stripe_InvalidRequestError')) {
+	require(dirname(__FILE__) . '/Stripe/InvalidRequestError.php');
+}
+if (!class_exists('Stripe_RateLimitError')) {
+	require(dirname(__FILE__) . '/Stripe/RateLimitError.php');
+}
 
 // Plumbing
-require(dirname(__FILE__) . '/Stripe/Object.php');
-require(dirname(__FILE__) . '/Stripe/ApiRequestor.php');
-require(dirname(__FILE__) . '/Stripe/ApiResource.php');
-require(dirname(__FILE__) . '/Stripe/SingletonApiResource.php');
-require(dirname(__FILE__) . '/Stripe/AttachedObject.php');
-require(dirname(__FILE__) . '/Stripe/List.php');
+if (!class_exists('Stripe_Object')) {
+	require(dirname(__FILE__) . '/Stripe/Object.php');
+}
+if (!class_exists('Stripe_ApiRequestor')) {
+	require(dirname(__FILE__) . '/Stripe/ApiRequestor.php');
+}
+if (!class_exists('Stripe_ApiResource')) {
+	require(dirname(__FILE__) . '/Stripe/ApiResource.php');
+}
+if (!class_exists('Stripe_SingletonApiResource')) {
+	require(dirname(__FILE__) . '/Stripe/SingletonApiResource.php');
+}
+if (!class_exists('Stripe_AttachedObject')) {
+	require(dirname(__FILE__) . '/Stripe/AttachedObject.php');
+}
+if (!class_exists('Stripe_List')) {
+	require(dirname(__FILE__) . '/Stripe/List.php');
+}
 
 // Stripe API Resources
-require(dirname(__FILE__) . '/Stripe/Account.php');
-require(dirname(__FILE__) . '/Stripe/Card.php');
-require(dirname(__FILE__) . '/Stripe/Balance.php');
-require(dirname(__FILE__) . '/Stripe/BalanceTransaction.php');
-require(dirname(__FILE__) . '/Stripe/Charge.php');
-require(dirname(__FILE__) . '/Stripe/Customer.php');
-require(dirname(__FILE__) . '/Stripe/Invoice.php');
-require(dirname(__FILE__) . '/Stripe/InvoiceItem.php');
-require(dirname(__FILE__) . '/Stripe/Plan.php');
-require(dirname(__FILE__) . '/Stripe/Subscription.php');
-require(dirname(__FILE__) . '/Stripe/Token.php');
-require(dirname(__FILE__) . '/Stripe/Coupon.php');
-require(dirname(__FILE__) . '/Stripe/Event.php');
-require(dirname(__FILE__) . '/Stripe/Transfer.php');
-require(dirname(__FILE__) . '/Stripe/Recipient.php');
-require(dirname(__FILE__) . '/Stripe/ApplicationFee.php');
+if (!class_exists('Stripe_Account')) {
+	require(dirname(__FILE__) . '/Stripe/Account.php');
+}
+if (!class_exists('Stripe_Card')) {
+	require(dirname(__FILE__) . '/Stripe/Card.php');
+}
+if (!class_exists('Stripe_Balance')) {
+	require(dirname(__FILE__) . '/Stripe/Balance.php');
+}
+if (!class_exists('Stripe_BalanceTransaction')) {
+	require(dirname(__FILE__) . '/Stripe/BalanceTransaction.php');
+}
+if (!class_exists('Stripe_Charge')) {
+	require(dirname(__FILE__) . '/Stripe/Charge.php');
+}
+if (!class_exists('Stripe_Customer')) {
+	require(dirname(__FILE__) . '/Stripe/Customer.php');
+}
+if (!class_exists('Stripe_Invoice')) {
+	require(dirname(__FILE__) . '/Stripe/Invoice.php');
+}
+if (!class_exists('Stripe_InvoiceItem')) {
+	require(dirname(__FILE__) . '/Stripe/InvoiceItem.php');
+}
+if (!class_exists('Stripe_Plan')) {
+	require(dirname(__FILE__) . '/Stripe/Plan.php');
+}
+if (!class_exists('Stripe_Subscription')) {
+	require(dirname(__FILE__) . '/Stripe/Subscription.php');
+}
+if (!class_exists('Stripe_Token')) {
+	require(dirname(__FILE__) . '/Stripe/Token.php');
+}
+if (!class_exists('Stripe_Coupon')) {
+	require(dirname(__FILE__) . '/Stripe/Coupon.php');
+}
+if (!class_exists('Stripe_Event')) {
+	require(dirname(__FILE__) . '/Stripe/Event.php');
+}
+if (!class_exists('Stripe_Transfer')) {
+	require(dirname(__FILE__) . '/Stripe/Transfer.php');
+}
+if (!class_exists('Stripe_Recipient')) {
+	require(dirname(__FILE__) . '/Stripe/Recipient.php');
+}
+if (!class_exists('Stripe_ApplicationFee')) {
+	require(dirname(__FILE__) . '/Stripe/ApplicationFee.php');
+}


### PR DESCRIPTION
I was using this plugin with a site that used a different Stripe plugin, and of course there was a conflict because the libraries were already loaded. Thought it would be a harmless addition to check for their existence first.